### PR TITLE
Correct spelling of markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Markdown Extended includes lots of editing helpers and a `what you see is what y
 Find in command palette, or right click on an editor / workspace folder, and execute:
 
 - `Markdown: Export to File`
-- `Markdown: Export Markdwon to File`
+- `Markdown: Export Markdown to File`
 
 The export files are organized in `out` directory in the root of workspace folder by default.
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
     "markdownExtended.exportCurrent": "Export to File",
-    "markdownExtended.exportWorkspace": "Export Markdwon to File",
+    "markdownExtended.exportWorkspace": "Export Markdown to File",
     "markdownExtended.copy": "Copy HTML",
     "markdownExtended.copyWithStyle": "Copy HTML & Styles",
     "markdownExtended.pasteAsTable": "Paste as Table",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,6 +1,6 @@
 {
     "markdownExtended.exportCurrent": "导出到文件",
-    "markdownExtended.exportWorkspace": "导出 Markdwon 到文件",
+    "markdownExtended.exportWorkspace": "导出 Markdown 到文件",
     "markdownExtended.copy": "复制 HTML",
     "markdownExtended.copyWithStyle": "复制 HTML (含样式)",
     "markdownExtended.pasteAsTable": "粘贴为表格",


### PR DESCRIPTION
Three instances of "markdwon" have been corrected to "markdown".