### PR TITLE
Fix with Fullwidth Comma & CJK Comma

### DIFF
--- a/src/services/common/tools.ts
+++ b/src/services/common/tools.ts
@@ -94,7 +94,9 @@ export async function showExportReport(report: ExportRport) {
  */
 export function MonoSpaceLength(text: string): number {
     // https://zhuanlan.zhihu.com/p/33335629
-    const CJKVReg = /[\u3006\u3007\u3021-\u3029\u3038-\u303A\u3400-\u4DB5\u4E00-\u9FEA\uF900-\uFA6D\uFA70-\uFAD9\u{17000}-\u{187EC}\u{18800}-\u{18AF2}\u{1B170}-\u{1B2FB}\u{20000}-\u{2A6D6}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}\u{2F800}-\u{2FA1D}]+/ug;
+    // https://zh.wikipedia.org/wiki/%E4%B8%AD%E6%97%A5%E9%9F%A9%E7%AC%A6%E5%8F%B7%E5%92%8C%E6%A0%87%E7%82%B9
+    // https://zh.wikipedia.org/wiki/%E5%85%A8%E5%BD%A2%E5%92%8C%E5%8D%8A%E5%BD%A2
+    const CJKVReg = /[\u2190-\u2193\u2502\u25A0\u25CB\u3000-\u303F\u309B\u309C\u30A1-\u30AB\u30AD\u30AF\u30B1\u30B3\u30B5\u30B7\u30B9\u30BB\u30BD\u30BF\u30C1\u30C3\u30C4\u30C6\u30C8\u30CA-\u30CF\u30D2\u30D5\u30D8\u30DB\u30DE\u30DF\u30E0\u30E1\u30E2\u30E4\u30E6\u30E8\u30E9\u30EA-\u30ED\u30EF\u30F3\u30FC\u3131-\u3164\u3400-\u4DB5\u4E00-\u9FEA\uF900-\uFA6D\uFA70-\uFAD9\uFF01-\uFF60\uFFE0-\uFFE6\u{17000}-\u{187EC}\u{18800}-\u{18AF2}\u{1B170}-\u{1B2FB}\u{20000}-\u{2A6D6}\u{2A700}-\u{2B734}\u{2B740}-\u{2B81D}\u{2B820}-\u{2CEA1}\u{2CEB0}-\u{2EBE0}\u{2F800}-\u{2FA1D}]+/ug;
     return text.length * 2 - text.replace(CJKVReg, '').length;
 
 }


### PR DESCRIPTION
Now it's error format with width  Fullwidth Comma & CJK Comma

Now it is like this:
![annotation 2018-12-21 104437](https://user-images.githubusercontent.com/5875432/50322104-b7a16700-050e-11e9-994f-82f4f17da4be.jpg)

After fix will be like this:
![annotation 2018-12-21 104747](https://user-images.githubusercontent.com/5875432/50322115-c5ef8300-050e-11e9-8048-881a5ab067a8.jpg)

Charsets come from:
https://zh.wikipedia.org/wiki/%E5%85%A8%E5%BD%A2%E5%92%8C%E5%8D%8A%E5%BD%A2
https://zh.wikipedia.org/wiki/%E4%B8%AD%E6%97%A5%E9%9F%A9%E7%AC%A6%E5%8F%B7%E5%92%8C%E6%A0%87%E7%82%B9

I think this pr will resolve all full width charsets.

Please check it .