### PR TITLE
Preserve table indentation and handle code spans

### DIFF
--- a/src/services/table/mdTable.ts
+++ b/src/services/table/mdTable.ts
@@ -12,14 +12,16 @@ export class MDTable {
     private _data: string[][];
     private _headerRowCount: number;
     private _aligns: TableAlign[];
+    private _indentation: string;
     private _columnWidths: number[];
     private _columnCount: number;
     private _rowCount: number;
     private _rowMergeFlags: boolean[] = [];
 
-    constructor(data: string[][], headerRowCount: number) {
+    constructor(data: string[][], headerRowCount: number, indentation: string = "") {
         this.data = data;
         this._headerRowCount = headerRowCount;
+        this._indentation = indentation;
     }
     public get data(): string[][] {
         return this._data;
@@ -54,6 +56,9 @@ export class MDTable {
         if (this._data[0].length !== aligns.length)
             throw new Error("Align settings count and column count mismatch!");
         this._aligns = aligns;
+    }
+    public get indentation(): string {
+        return this._indentation;
     }
     public get columnWidths(): number[] {
         return this._columnWidths;

--- a/src/services/table/mdTableStringify.ts
+++ b/src/services/table/mdTableStringify.ts
@@ -2,8 +2,8 @@ import { MDTable, TableAlign } from "./mdTable";
 import { MonoSpaceLength } from "./monospace";
 export function stringifyMDTable(table: MDTable, compact?: boolean, padding?: number): string {
     padding = padding || 1;
-    let rows = table.data.map((row, i) => stringifyRow(row, table.columnWidths, table.aligns, table.rowMergeFlags[i], compact, padding));
-    let Sep = stringifyHeaderSeperator(table, compact, padding);
+    let rows = table.data.map((row, i) => table.indentation + stringifyRow(row, table.columnWidths, table.aligns, table.rowMergeFlags[i], compact, padding));
+    let Sep = table.indentation + stringifyHeaderSeperator(table, compact, padding);
     rows.splice(table.headerRowCount, 0, Sep);
     return rows.join('\n');
 }


### PR DESCRIPTION
This pull request fixes both issues from #138.

1. The indentation of the first line of the table is preserved and applied to all the subsequent lines in the table.
2. Code spans inside of tables are parsed correctly so that pipe characters occurring inside of code spans will not be treated as column delimiters.