### PR TITLE
allow use top meta props in headerTemplate and footerTemplate

### DIFF
--- a/src/services/exporter/puppeteer.ts
+++ b/src/services/exporter/puppeteer.ts
@@ -5,10 +5,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { MarkdownDocument } from '../common/markdownDocument';
 import { mkdirsSync, mergeSettings } from '../common/tools';
-import { renderPage } from './shared';
+import { renderPage, replaceTokens } from './shared';
 import { MarkdownExporter, exportFormat, Progress, ExportItem } from './interfaces';
 import { config } from '../common/config';
-import { context } from '../../extension';
 
 class PuppeteerExporter implements MarkdownExporter {
     async Export(items: ExportItem[], progress: Progress) {
@@ -67,6 +66,16 @@ class PuppeteerExporter implements MarkdownExporter {
                     document.meta.puppeteerPDF
                 );
                 ptConf = Object.assign(ptConf, { path: item.fileName });
+                
+                //allow to use {{ metaRawVariable }} in header and footer
+                let meta = document?.meta?.raw
+                if (meta && ptConf.headerTemplate){
+                    ptConf.headerTemplate = replaceTokens(ptConf.headerTemplate, meta)
+                }
+                if (meta && ptConf.footerTemplate){
+                    ptConf.footerTemplate = replaceTokens(ptConf.footerTemplate, meta)
+                }
+
                 await page.pdf(ptConf);
                 break;
             case exportFormat.JPG:

--- a/src/services/exporter/shared.ts
+++ b/src/services/exporter/shared.ts
@@ -109,3 +109,14 @@ export async function ensureMarkdownEngine() {
         await vscode.commands.executeCommand('markdown.api.render', 'init markdown engine');
     }
 }
+
+/**
+ * Replace {{ token }} at content string, with context property with name token
+ * @param content text for replace
+ * @param context object for replace values
+ * @returns result text
+ */
+export function replaceTokens(content: string, context: object): string
+{
+    return content.replace(/\{\{\s*([^{} ]+)\s*\}\}/gi, (match, key) => context[key] || key);
+}


### PR DESCRIPTION
Allow use top meta properties in headerTemplate and footerTemplate when export to pdf.
Use lable "{{ author }}" at headerTemplate or footerTemplate  to replace them by top property "author".

Example.
Set at md file meta data with title, date and author. Then set headerTemplate with lables {{author}} and {{date}}. And export md to pdf.

``` some.md
---
title: "some title"
date: "2024-01-01"
author: "Me"
---
# test

```

Set headerTemplate setting to : 
`<div style='font-size: 9px; margin-left: 1cm;'> <span class='title'></span></div> <div style='font-size: 9px; margin-left: auto; margin-right: 1cm; '> {{author}}, {{date}} </div>`

Export to pdf. At header: 
`some title              Me, 2024-01-01`

it my first public PR